### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/collections.ts
+++ b/app/collections.ts
@@ -2,7 +2,7 @@ import {apiUrl, webUrl} from "./config";
 
 // External
 import * as request from "request";
-import * as uuid from "node-uuid";
+import * as uuid from "uuid";
 import * as _ from "lodash";
 import * as fs from "fs";
 

--- a/dist/collections.js
+++ b/dist/collections.js
@@ -7,7 +7,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var config_1 = require("./config");
 // External
 var request = require("request");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 var _ = require("lodash");
 var fs = require("fs");
 var collection_1 = require("./interfaces/collection");

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "babel-polyfill": "^6.5.0",
     "lodash": "^4.3.0",
-    "node-uuid": "^1.4.7",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "uuid": "^3.0.0"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/typings.json
+++ b/typings.json
@@ -7,7 +7,7 @@
     "chai": "github:DefinitelyTyped/DefinitelyTyped/chai/chai.d.ts#3030a4be536b6530c06b80081f1333dc0de4d703",
     "assertion-error": "github:DefinitelyTyped/DefinitelyTyped/assertion-error/assertion-error.d.ts#3030a4be536b6530c06b80081f1333dc0de4d703",
     "lodash": "github:DefinitelyTyped/DefinitelyTyped/lodash/lodash.d.ts#44c9273e1e92bc95368f599d1dcda9f560a68956",
-    "node-uuid": "github:DefinitelyTyped/DefinitelyTyped/node-uuid/node-uuid.d.ts#44c9273e1e92bc95368f599d1dcda9f560a68956",
+    "uuid": "github:DefinitelyTyped/DefinitelyTyped/node-uuid/node-uuid.d.ts#44c9273e1e92bc95368f599d1dcda9f560a68956",
     "node-uuid-base": "github:DefinitelyTyped/DefinitelyTyped/node-uuid/node-uuid-base.d.ts#44c9273e1e92bc95368f599d1dcda9f560a68956",
     "node-uuid-cjs": "github:DefinitelyTyped/DefinitelyTyped/node-uuid/node-uuid-cjs.d.ts#44c9273e1e92bc95368f599d1dcda9f560a68956",
     "form-data": "github:DefinitelyTyped/DefinitelyTyped/form-data/form-data.d.ts#bcd5761826eb567876c197ccc6a87c4d05731054"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.